### PR TITLE
Add types for `svelte-filepond`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,9 +109,9 @@
       "dev": true
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -275,9 +275,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "picomatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^6.0.0",
         "rollup": "^1.20.0",
-        "rollup-plugin-svelte": "^5.0.0",
-        "svelte": "^3.55.0"
+        "rollup-plugin-svelte": "^6.1.1",
+        "svelte": "^3.31.0"
       },
       "peerDependencies": {
         "filepond": ">=3.7.x <5.x"
@@ -153,14 +153,18 @@
       }
     },
     "node_modules/rollup-plugin-svelte": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-5.2.3.tgz",
-      "integrity": "sha512-513vOht9A93OV7fvmpIq8mD1JFgTZ5LidmpULKM2Od9P1l8oI5KwvO32fwCnASuVJS1EkRfvCnS7vKQ8DF4srg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.1.1.tgz",
+      "integrity": "sha512-ijnm0pH1ScrY4uxwaNXBpNVejVzpL2769hIEbAlnqNUWZrffLspu5/k9/l/Wsj3NrEHLQ6wCKGagVJonyfN7ow==",
       "dev": true,
       "dependencies": {
         "require-relative": "^0.8.7",
         "rollup-pluginutils": "^2.8.2",
         "sourcemap-codec": "^1.4.8"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.19.2",
+        "svelte": "*"
       }
     },
     "node_modules/rollup-pluginutils": {
@@ -309,9 +313,9 @@
       }
     },
     "rollup-plugin-svelte": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-5.2.3.tgz",
-      "integrity": "sha512-513vOht9A93OV7fvmpIq8mD1JFgTZ5LidmpULKM2Od9P1l8oI5KwvO32fwCnASuVJS1EkRfvCnS7vKQ8DF4srg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.1.1.tgz",
+      "integrity": "sha512-ijnm0pH1ScrY4uxwaNXBpNVejVzpL2769hIEbAlnqNUWZrffLspu5/k9/l/Wsj3NrEHLQ6wCKGagVJonyfN7ow==",
       "dev": true,
       "requires": {
         "require-relative": "^0.8.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "svelte-filepond",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-filepond",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^6.0.0",
         "rollup": "^1.20.0",
         "rollup-plugin-svelte": "^5.0.0",
-        "svelte": "^3.0.0"
+        "svelte": "^3.55.0"
       },
       "peerDependencies": {
         "filepond": ">=3.7.x <5.x"
@@ -185,9 +185,9 @@
       "dev": true
     },
     "node_modules/svelte": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.24.1.tgz",
-      "integrity": "sha512-OX/IBVUJSFo1rnznXdwf9rv6LReJ3qQ0PwRjj76vfUWyTfbHbR9OXqJBnUrpjyis2dwYcbT2Zm1DFjOOF1ZbbQ==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
+      "integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -343,9 +343,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.24.1.tgz",
-      "integrity": "sha512-OX/IBVUJSFo1rnznXdwf9rv6LReJ3qQ0PwRjj76vfUWyTfbHbR9OXqJBnUrpjyis2dwYcbT2Zm1DFjOOF1ZbbQ==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
+      "integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "svelte": "src/index.js",
   "module": "dist/index.mjs",
   "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "files": [
     "src",
     "dist"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "types": "types/index.d.ts",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "types"
   ],
   "scripts": {
     "build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rollup/plugin-node-resolve": "^6.0.0",
     "rollup": "^1.20.0",
     "rollup-plugin-svelte": "^5.0.0",
-    "svelte": "^3.55.0"
+    "svelte": "^3.31.0"
   },
   "peerDependencies": {
     "filepond": ">=3.7.x <5.x"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^6.0.0",
     "rollup": "^1.20.0",
-    "rollup-plugin-svelte": "^5.0.0",
+    "rollup-plugin-svelte": "^6.1.1",
     "svelte": "^3.31.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@rollup/plugin-node-resolve": "^6.0.0",
     "rollup": "^1.20.0",
     "rollup-plugin-svelte": "^5.0.0",
-    "svelte": "^3.0.0"
+    "svelte": "^3.55.0"
   },
   "peerDependencies": {
     "filepond": ">=3.7.x <5.x"

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -1,95 +1,92 @@
-<svelte:options accessors/>
+<svelte:options accessors />
 
 <script>
-import { onDestroy, afterUpdate } from 'svelte';
-import * as FilePond from 'filepond';
+  import { onDestroy, afterUpdate } from "svelte";
+  import * as FilePond from "filepond";
 
-export const registerPlugin = FilePond.registerPlugin;
+  export const registerPlugin = FilePond.registerPlugin;
 
-// is FilePond supported
-export const isSupported = FilePond.supported();
+  // is FilePond supported
+  export const isSupported = FilePond.supported();
 
-// private props, root element + active instance of FilePond
-let root;
-let instance;
+  // private props, root element + active instance of FilePond
+  let root;
+  let instance;
 
-// base props for use on file input
-let klass = undefined;
-export { klass as class };
-export let id = undefined;
-export let name = undefined;
-export let allowMultiple = undefined;
-export let required = undefined;
-export let captureMethod = undefined;
-export let acceptedFileTypes = undefined;
+  // base props for use on file input
+  let klass = undefined;
+  export { klass as class };
+  export let id = undefined;
+  export let name = undefined;
+  export let allowMultiple = undefined;
+  export let required = undefined;
+  export let captureMethod = undefined;
+  export let acceptedFileTypes = undefined;
 
-// placeholder fn for methods
-const noop = () => {};
+  // placeholder fn for methods
+  const noop = () => {};
 
-// functions to call on this component (if it's initialised)
-export let addFile = noop;
-export let addFiles = noop;
-export let browse = noop;
-export let fireSync = noop;
-export let getFile = noop;
-export let getFiles = noop;
-export let moveFile = noop;
-export let prepareFile = noop;
-export let prepareFiles = noop;
-export let processFile = noop;
-export let processFiles = noop;
-export let removeFile = noop;
-export let removeFiles = noop;
-export let sort = noop;
+  // functions to call on this component (if it's initialised)
+  export let addFile = noop;
+  export let addFiles = noop;
+  export let browse = noop;
+  export let fireSync = noop;
+  export let getFile = noop;
+  export let getFiles = noop;
+  export let moveFile = noop;
+  export let prepareFile = noop;
+  export let prepareFiles = noop;
+  export let processFile = noop;
+  export let processFiles = noop;
+  export let removeFile = noop;
+  export let removeFiles = noop;
+  export let sort = noop;
 
-// this lifecycle method will handle updating and creating the FilePond instance
-afterUpdate(() => {
+  // this lifecycle method will handle updating and creating the FilePond instance
+  afterUpdate(() => {
     if (!isSupported) return;
     if (!instance) {
+      // create instance
+      instance = FilePond.create(root, { ...$$props });
 
-        // create instance
-        instance = FilePond.create(root, { ...$$props });
-
-        // Reference pond methods to FilePond component instance
-        addFile = instance.addFile;
-        addFiles = instance.addFiles;
-        removeFile = instance.removeFile;
-        removeFiles = instance.removeFiles;
-        browse = instance.browse;
-        fireSync = instance.fireSync;
-        getFile = instance.getFile;
-        getFiles = instance.getFiles;
-        moveFile = instance.moveFile;
-        prepareFile = instance.prepareFile;
-        prepareFiles = instance.prepareFiles;
-        processFile = instance.processFile;
-        processFiles = instance.processFiles;
-        removeFile = instance.removeFile;
-        removeFiles = instance.removeFiles;
-        sort = instance.sort;
-
+      // Reference pond methods to FilePond component instance
+      addFile = instance.addFile;
+      addFiles = instance.addFiles;
+      removeFile = instance.removeFile;
+      removeFiles = instance.removeFiles;
+      browse = instance.browse;
+      fireSync = instance.fireSync;
+      getFile = instance.getFile;
+      getFiles = instance.getFiles;
+      moveFile = instance.moveFile;
+      prepareFile = instance.prepareFile;
+      prepareFiles = instance.prepareFiles;
+      processFile = instance.processFile;
+      processFiles = instance.processFiles;
+      sort = instance.sort;
+    } else {
+      instance.setOptions($$props);
     }
-    else {
-        instance.setOptions($$props);
-    }
-});
+  });
 
-// cleans up the component
-onDestroy(() => {
+  // cleans up the component
+  onDestroy(() => {
     if (!instance) return;
     instance.destroy();
     instance = undefined;
-})
+  });
 </script>
 
 <div class="filepond--wrapper">
-    <input type="file" 
-        bind:this={root}
-        {id}
-        {name}
-        class={klass}
-        accept={acceptedFileTypes}
-        multiple={allowMultiple}
-        required={required}
-        capture={captureMethod}>
+  <input
+    type="file"
+    bind:this={root}
+    {id}
+    {name}
+    class={klass}
+    accept={acceptedFileTypes}
+    multiple={allowMultiple}
+    {required}
+    capture={captureMethod}
+  />
 </div>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,50 @@
-import type { FilePondOptions } from "filepond";
+import type { FilePond as FilePondInstance, FilePondOptions } from "filepond";
 import type { SvelteComponentTyped } from "svelte";
 
 export * from "filepond";
 
-export default class FilePond extends SvelteComponentTyped<FilePondOptions> {}
+type ComponentProps = FilePondOptions & {
+  class?: string;
+  id?: string;
+  /** A string specifying the name of the input control. */
+  name: string;
+  /**
+   * The Boolean multiple attribute, if set, means the form control accepts one or more values.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/multiple
+   */
+  allowMultiple?: boolean;
+  /** 
+   * The Boolean required attribute, if present, indicates that the user must specify a value for the input before the owning form can be submitted. 
+   **/
+  required?: boolean;
+  /**
+   * The capture attribute specifies that, optionally, a new file should be captured, and which device should be used to capture that new media of a type defined by the accept attribute.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture
+   */
+  captureMethod?: 'user' | 'environment' | boolean;
+  /** 
+   * Comma-separated list of accepted file types
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#attr-accept
+   **/
+  acceptedFileTypes?: string;
+
+  addFile?: FilePondInstance['addFile'];
+  addFiles?: FilePondInstance['addFiles'];
+  removeFile?: FilePondInstance['removeFile'];
+  removeFiles?: FilePondInstance['removeFiles'];
+  browse?: FilePondInstance['browse'];
+  getFile?: FilePondInstance['getFile'];
+  getFiles?: FilePondInstance['getFiles'];
+  moveFile?: FilePondInstance['moveFile'];
+  prepareFile?: FilePondInstance['prepareFile'];
+  prepareFiles?: FilePondInstance['prepareFiles'];
+  processFile?: FilePondInstance['processFile'];
+  processFiles?: FilePondInstance['processFiles'];
+  sort?: FilePondInstance['sort'];
+}
+
+/**
+ * The FilePond Svelte Component functions as a tiny adapter for the FilePond object so it's easier to use with Svelte.
+ * @url https://pqina.nl/filepond/docs/getting-started/installation/svelte/
+ */
+export default class FilePond extends SvelteComponentTyped<ComponentProps> {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,6 @@
+import type { FilePondOptions } from "filepond";
+import type { SvelteComponentTyped } from "svelte";
+
+export * from "filepond";
+
+export default class FilePond extends SvelteComponentTyped<FilePondOptions> {}


### PR DESCRIPTION
This PR:

- upgrades `svelte` to `^3.31` because the `SvelteComponentTyped` required to do this was added in that release.
- adds types for the both the default export and re-exported FilePond exports
- updates `rollup-plugin-svelte` to v6.1.1, which fixes a broken require that was throwing when running the build
  - There's also a v7.x.x of `rollup-plugin-svelte` but it requires upgrading rollup to v2, a new major.
- updates the `dist/` folder of this package (this could possibly be removed as `npm run build` is also the `prepublish` action?)